### PR TITLE
Electron FootPrint

### DIFF
--- a/Utils/plugins/BuildFile.xml
+++ b/Utils/plugins/BuildFile.xml
@@ -1,9 +1,5 @@
-<use name="RecoEcal/EgammaCoreTools"/>
-<use name="RecoEgamma/EgammaTools"/>
-<use name="root"/>
-<use name="roottmva"/>
-<!--use name="rootcintex"/-->
-<use name="fastjet"/>
+<library name="BaconProdUtilsPlugins" file="*.cc"/>
+<use name="BaconProd/Utils"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
@@ -14,7 +10,9 @@
 <use name="RecoEgamma/EgammaIsolationAlgos"/>
 <use name="DataFormats/Math"/>
 <!--  -->
-<flags CXXFLAGS="-g -Wall"/>
-<export>
-  <lib name="1"/>
-</export>
+<use name="clhep"/>
+<use name="root"/>
+<use name="RooFit"/>
+<use name="roottmva"/>
+<use name="rootrflx"/>
+<flags EDM_PLUGIN="1"/>

--- a/Utils/plugins/ElectornFootPrintProducer.cc
+++ b/Utils/plugins/ElectornFootPrintProducer.cc
@@ -1,0 +1,195 @@
+// -*- C++ -*-
+//
+// Class:      ElectronFootPrintProducer
+// 
+/*
+ Description: This class implements the search for footprint in gedElectrons
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Andrea Carlo Marini
+//         Created:  Wed, 19 Oct 2016 13:38:32 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+// EGamma
+//
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.h"
+// ROOT
+#include "TLorentzVector.h"
+
+//
+// class declaration
+//
+
+class ElectronFootPrintProducer : public edm::stream::EDProducer<> {
+   public:
+      explicit ElectronFootPrintProducer(const edm::ParameterSet&);
+      ~ElectronFootPrintProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      void beginStream(edm::StreamID) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
+      void endStream() override;
+
+      void beginRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
+      // ----------member data ---------------------------
+      std::string label_{"valueMap"};
+      std::unique_ptr<PFBlockBasedIsolation> thePFBlockBasedIsolation_;
+
+      // token
+      edm::EDGetTokenT<reco::GsfElectronCollection> electronsT_;
+      edm::EDGetTokenT<reco::PFCandidateCollection> pfCandidatesT_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+ElectronFootPrintProducer::ElectronFootPrintProducer(const edm::ParameterSet& iConfig)
+{
+   // name of the value map
+   label_ = iConfig.getParameter<std::string>("label");
+
+   //consumes 
+   pfCandidatesT_ = consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandidates"));
+   electronsT_    = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("electrons"));
+   // produces  
+   produces< edm::ValueMap<TLorentzVector> > (label_); 
+  
+}
+
+
+ElectronFootPrintProducer::~ElectronFootPrintProducer()
+{
+ 
+   // do anything here that needs to be done at destruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+ElectronFootPrintProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+     // get ged electrons
+     edm::Handle<reco::GsfElectronCollection> electronsHandle;
+     iEvent.getByToken(electronsT_,electronsHandle);
+
+     // Get the  PF candidates collection
+     edm::Handle<reco::PFCandidateCollection> pfCandidateHandle;
+     iEvent.getByToken(pfCandidatesT_,pfCandidateHandle);
+
+     // store the ValueMap
+     std::vector<TLorentzVector> product;
+
+     // Loop over gedElectrons
+     for(const auto& ele : *electronsHandle) {
+	     reco::SuperClusterRef sc  =  ele.superCluster ();
+	     TLorentzVector fp; // footprint
+	     // -- ECAL SC based matching
+	     /*
+	     for(const auto & cand: pfCandidateHandle)
+	     {
+		bool inFootPrint=false;
+		if (sc == cand.superClusterRef() ) { inFootPrint = true;}
+		//if (  ele.bestTrackRef() == cand.trackRef() ) { inFootPrint = true;} // ??
+		if (inFootPrint)
+		{
+			TLorentzVector candV ( cand.px(),cand.py(),cand.pz(),cand.energy() );	
+			fp+=candV;
+		}
+	     }
+	     */
+	     // -- PF Based --
+	     for (int iC=0; iC< ele.numberOfSourceCandidatePtrs() ;++iC)
+	     {
+	    		const auto& sc = ele.sourceCandidatePtr(iC);  
+			TLorentzVector candV ( cand.px(),cand.py(),cand.pz(),cand.energy() );	
+			fp+=candV;
+	     }
+	
+	     product.push_back(fp);
+     } // end loop over electrons
+
+     // put in Event
+     std::unique_ptr<edm::ValueMap<TLorentzVector>> out(new edm::ValueMap<TLorentzVector>());
+     edm::ValueMap<TLorentzVector>::Filler filler(*out);
+     filler.insert(electronsHandle, product.begin(), product.end());
+     filler.fill();
+     iEvent.put(out, label_.c_str());
+}
+
+void 
+ElectronFootPrintProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup){
+	 thePFBlockBasedIsolation_ . reset( new PFBlockBasedIsolation() );
+	 edm::ParameterSet pfBlockBasedIsolationSetUp = conf_.getParameter<edm::ParameterSet>("pfBlockBasedIsolationSetUp"); 
+	 thePFBlockBasedIsolation_ ->setup(pfBlockBasedIsolationSetUp);
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+ElectronFootPrintProducer::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+ElectronFootPrintProducer::endStream() {
+}
+
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+ElectronFootPrintProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ElectronFootPrintProducer);

--- a/Utils/python/ElectronFootPrint_cfi.py
+++ b/Utils/python/ElectronFootPrint_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+from RecoEgamma.EgammaIsolationAlgos.pfBlockBasedIsolation_cfi import *
+
+electronFootPrint = cms.EDProducer('ElectronFootPrintProducer',
+	label=cms.string("electronFootPrint"),
+	electrons = cms.InputTag("gedGsfElectrons"), 
+	pfCandidates = cms.InputTag("particleFlow"),
+	pfBlockBasedIsolationSetUp=cms.PSet(pfBlockBasedIsolation) 
+)

--- a/Utils/src/classes.h
+++ b/Utils/src/classes.h
@@ -1,0 +1,11 @@
+#include "DataFormats/Common/interface/ValueMap.h"  
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "TLorentzVector.h"
+
+namespace {
+	struct dictionary {
+	edm::ValueMap<TLorentzVector> my_ValueMapTLorentzVector;
+	edm::Wrapper<edm::ValueMap<TLorentzVector> > my_WrapperValueMapTLorentzVector;
+	};
+}

--- a/Utils/src/classes_def.xml
+++ b/Utils/src/classes_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+	<class name="edm::ValueMap<TLorentzVector>" />
+	<class name="edm::Wrapper<edm::ValueMap<TLorentzVector> >" />
+</lcgdict>

--- a/Utils/test/ConfFile_cfg.py
+++ b/Utils/test/ConfFile_cfg.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ELEMAP")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.source = cms.Source("PoolSource",
+    # replace 'myfile.root' with the source file you want to use
+    fileNames = cms.untracked.vstring(
+        '/store/mc/RunIIFall15DR76/DYToEE_13TeV-amcatnloFXFX-pythia8/AODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/80000/FCDCED20-6CCE-E511-906A-02163E00F4A6.root'
+    )
+)
+
+process.load("BaconProd.Utils.ElectronFootPrint_cfi")
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('myOutputFile.root')
+)
+
+  
+process.p = cms.Path(process.electronFootPrint)
+
+process.e = cms.EndPath(process.out)


### PR DESCRIPTION
**Need to be tested.**

Electrons in AOD/MiniAOD are ged-gsf, while met is done with PFCandidates,
therefore we need to save the footprint of the electrons ( p4-sum of pf-candidates associated)

In runI the footprint was done with the association with SC. (commented code should do that)
I need to check that the source candidate are all and only PFCandidates, w/o duplicates.

-Andrea
